### PR TITLE
Expose optional webDAV port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     build: seafile
     ports:
       - 80:80/tcp
+      - 8080:8080/tcp # optional webDAV port
     volumes:
       - data:/shared
     environment:


### PR DESCRIPTION
Feature can be enabled by editing
/shared/seafile/conf/seafdav.conf as per
https://manual.seafile.com/extension/webdav/

Signed-off-by: Kyle Harding <kyle@balena.io>